### PR TITLE
Combine HTTP redirect for both www and non-www

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -39,12 +39,12 @@ http {
 		server 10.132.55.149:8000; # example-b
 	}
 
-	# Redirect www HTTP clients to non-www HTTPS permanently
+	# Redirect www and non-www HTTP clients to non-www HTTPS permanently
 	# See http://nginx.org/en/docs/http/converting_rewrite_rules.html
 	server {
 		listen 80;
 		listen [::]:80;
-		server_name www.example.com;
+		server_name example.com www.example.com;
 		return 301 https://example.com$request_uri;
 	}
 
@@ -55,15 +55,6 @@ http {
 		server_name www.example.com;
 		include conf.d/https.conf;
 		return 301 https://example.com$request_uri;
-	}
-
-	# Redirect non-HTTPs clients to non-www HTTPS permanently
-	server {
-		listen 80;
-		listen [::]:80;
-		server_name example.com;
-		return 301 https://example.com$request_uri;
-		include conf.d/https.conf;
 	}
 
 	# Single HTTPS non-www point all browsers will talk to


### PR DESCRIPTION
You can easily put two `server_name` space-separated to have one `server` block for HTTP www and non-www redirect.

You also don’t need to include `https.conf` for HTTP:

```nginx
server {
	listen 80;
	listen [::]:80;
	server_name example.com;
	return 301 https://example.com$request_uri;
	include conf.d/https.conf;
}
```